### PR TITLE
feat(style): HTML in Markdown Styling

### DIFF
--- a/public/content/docs/mels-hack-the-missing-bits/index.en.md
+++ b/public/content/docs/mels-hack-the-missing-bits/index.en.md
@@ -36,7 +36,7 @@ For brevity and clarity, we will use a mock instruction layout in which each com
 
 Something like:
 
-<figure>
+<figure data-type="no-border">
 <table data-type="bit-layout">
 <tr>
 <td>MSB<</td>
@@ -70,7 +70,7 @@ This layout is missing a part described earlier in the story:
 
 Thus, the bit layout of the instruction needs an additional component for the next address `(N)`. Its location doesn't affect the hack, as described in the story, but let's place it on the least significant bits, to be on the safe side:
 
-<figure>
+<figure data-type="no-border">
 <table data-type="bit-layout">
 <tr>
 <td>MSB<</td>
@@ -111,7 +111,7 @@ We know that the `(A)` bits are lower than the `(C)` bits, because **Ed Nather**
 
 If incrementing the address span overflows into the opcode span, then the bit order between them is established:
 
-<figure>
+<figure data-type="no-border">
 <table data-type="bit-layout">
 <tr>
 <td>MSB<</td>
@@ -157,7 +157,7 @@ After recovering from this blow to my computer ego, I took the basic step requir
 
 Quite simply, the hack, as described in **Ed Nather**'s account, is impossible on the RPC-4000. The opcode `(C)` field, supposedly modified by the overflow, is in the least significant bits of the instruction. In the terms used above:
 
-<figure>
+<figure data-type="no-border">
 <table data-type="bit-layout">
 <tr>
 <td>MSB<</td>
@@ -188,7 +188,7 @@ Obviously, once we rule out **Ed Nather**'s code flow, all options are on the ta
 
 It turns out that the architecture of the RPC-4000 does provide for a code layout which would accomplish the feat by using an overflow. Using our simplified bit layout, let's assume that the instruction, at some point, reaches the value:
 
-<figure>
+<figure data-type="no-border">
 <table data-type="bit-layout">
 <tr>
 <td>MSB<</td>
@@ -211,7 +211,7 @@ It turns out that the architecture of the RPC-4000 does provide for a code layou
 
 In this diagram, the opcode doesn't matter, it can be any part of the program logic. The address of the next instruction is `111`, so that's where the next step of the loop is located. The data address is also `111`, which doesn't pose a problem: The instruction may not even need an operand, or the value in the `111` address may be commensurate with the program logic. Normally, the program would proceed to the instruction in location 111. Now, when we try to increment the data address by `1` (adding `1000`), the "overflow" of the field zeroes out the `(A)` and `(N)` fields, yielding this instruction:
 
-<figure>
+<figure data-type="no-border">
 <table data-type="bit-layout">
 <tr>
 <td>MSB<</td>
@@ -264,7 +264,7 @@ It's reasonable to assume that standard training on the RPC-4000 included only t
 
 Instead of running a test, Mel kept incrementing the value of the `(A)` field, as described in the story. This eventually led to an overflow of the entire register, provided the index register bit `(X)` was on – exactly as Nather remembered. Using 101 as the `TBC` opcode yields the following sequence:
 
-<figure>
+<figure data-type="codeblock">
              1111111101
         MSB <----------> LSB
 

--- a/src/components/content/content-blocks/table/table.st.css
+++ b/src/components/content/content-blocks/table/table.st.css
@@ -6,6 +6,5 @@
 
 .root[data-type='bit-layout'] td,
 .root[data-type='bit-layout'] th {
-	border: 1px solid black;
-	border-top: none;
+	padding: 0.25rem 0.5rem;
 }

--- a/src/components/content/content-blocks/table/table.tsx
+++ b/src/components/content/content-blocks/table/table.tsx
@@ -8,7 +8,6 @@ import { st, classes } from "./table.st.css";
 import { mlUtils } from "../../../../lib/ml-utils";
 import { useComponentAttributes } from "../../../use-component-attributes";
 
-
 export const Table = ({
 	componentData,
 	className

--- a/src/components/content/content-component/content-component.st.css
+++ b/src/components/content/content-component/content-component.st.css
@@ -29,7 +29,11 @@
 		heading_5,
 		heading_6,
 		figcaption,
-		cite
+		cite,
+		table,
+		tr,
+		td,
+		th,
 	)),
 	listType(enum(ul, ol));
 }

--- a/src/pages/page-base-mixin.st.css
+++ b/src/pages/page-base-mixin.st.css
@@ -108,6 +108,11 @@
 	border-color: value(ImageBorderColor);
 }
 
+.root::contentComponent:type(figure) Table th,
+.root::contentComponent:type(figure) Table td {
+	border-color: value(ImageBorderColor);
+}
+
 .root::meta {
 	color: value(ArticleMetaTextColor);
 }

--- a/src/pages/page-base.st.css
+++ b/src/pages/page-base.st.css
@@ -4,6 +4,7 @@
 @st-import ContentComponent from "../components/content/content-component/content-component.st.css";
 @st-import Link from "../components/content/content-blocks/link/link.st.css";
 @st-import CodeBlock from "../components/content/content-blocks/code-block/code-block.st.css";
+@st-import Table from "../components/content/content-blocks/table/table.st.css";
 @st-import Figure from "../components/content/content-blocks/figure/figure.st.css";
 @st-import [
 	h1,
@@ -93,6 +94,7 @@
 }
 .root::contentComponent:type(figure) :type(figcaption) {
 	text-align: center;
+	padding: 1rem 0;
 }
 
 .root:textDirection(rtl)::contentComponent:type(blockquote) {
@@ -102,6 +104,11 @@
 	border-right: value(BlockQuoteBorder);
 }
 
+/* .root::contentComponent:type(table) .root::contentComponent:type(th), */
+.root::contentComponent:type(figure) Table th,
+.root::contentComponent:type(figure) Table td {
+	border: 1px solid;
+}
 
 .root::contentComponent:listType(ul),
 .root::contentComponent:listType(ol) {
@@ -136,6 +143,14 @@
 	margin: 2rem 0;
 }
 .root::contentComponent:type(figure) img {
+	display: block;
+}
+
+.root::contentComponent:type(figure)[data-type="no-border"] {
+	border: none;
+}
+.root::contentComponent:type(figure)[data-type="codeblock"] {
+	border: none;
 	display: block;
 }
 


### PR DESCRIPTION
- Add no-border data-type to tables in Missing Bits
- Table component cleanup
- Support table in ContentComponent
- Style Table via PageBase
