### PR TITLE
Provide the documentPath in the page context

### DIFF
--- a/src/components/content/dynamic-content-viewer/dynamic-content-viewer.tsx
+++ b/src/components/content/dynamic-content-viewer/dynamic-content-viewer.tsx
@@ -54,7 +54,7 @@ export const DynamicContentViewer = ({
 		}
 		let docPath: string;
 		if (itemData.isRelative) {
-			docPath = router.asPath;
+			docPath = pageContext.documentPath || router.asPath;
 		}
 		pageContext.dynamicContentServer
 			.getItems({ type: itemData.type, locale, ids: [itemData.id], document: docPath })

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -2,10 +2,10 @@ import { LocaleContextProvider } from "../contexts/locale-context";
 import { PageContextProvider } from "../contexts/page-context";
 import { ThemeContextProvider } from "../contexts/theme-context";
 
-export const AppContext = ({ children, router }) => {
+export const AppContext = ({ children, router, documentPath }) => {
 	return (
 		<LocaleContextProvider router={router}>
-			<PageContextProvider>
+			<PageContextProvider documentPath={documentPath}>
 				<ThemeContextProvider>
 					<>{children}</>
 				</ThemeContextProvider>

--- a/src/contexts/page-context.tsx
+++ b/src/contexts/page-context.tsx
@@ -4,16 +4,16 @@ import { IPageContext } from "../interfaces/page-context";
 import { DynamicContentServer } from "../lib/dynamic-content-server";
 
 export class PageContext implements IPageContext {
-	constructor(public readonly dynamicContentServer: IDynamicContentServer) {}
+	constructor(public readonly dynamicContentServer: IDynamicContentServer, public documentPath: string) {}
 }
 
-const ctx = createContext<IPageContext>(new PageContext(null));
+const ctx = createContext<IPageContext>(new PageContext(null, ""));
 
 export const ReactPageContext: Context<IPageContext> = ctx;
 
-export const PageContextProvider = ({ children }) => (
+export const PageContextProvider = ({ documentPath, children }) => (
 	<ReactPageContext.Provider
-		value={new PageContext(new DynamicContentServer())}
+		value={new PageContext(new DynamicContentServer(), documentPath as string)}
 	>
 		{children}
 	</ReactPageContext.Provider>

--- a/src/interfaces/models.ts
+++ b/src/interfaces/models.ts
@@ -297,6 +297,7 @@ export interface SitePage {
 
 export interface IPageProps {
 	locale: string;
+	documentPath: string;
 	translate: (key: string) => string;
 	content: string;
 	className?: string;

--- a/src/interfaces/page-context.ts
+++ b/src/interfaces/page-context.ts
@@ -5,4 +5,8 @@ import { IDynamicContentServer } from "./dynamic-content";
  */
 export interface IPageContext {
 	readonly dynamicContentServer: IDynamicContentServer;
+	/**
+	 * The path of the document displayed in the current component
+	 */
+	readonly documentPath: string;
 }

--- a/src/lib/markdown-driver.ts
+++ b/src/lib/markdown-driver.ts
@@ -150,11 +150,9 @@ export function loadContentFolder(
 			// Use gray-matter to parse the post metadata section
 			const { data: matterData, content } = matter(fileContents);
 			const metaData = new PageMetaData(matterData);
-			const chapterId = "koan1"
 			const parsedPageData = new ParsedPageData({
 				metaData: metaData.toObject(),
 				id: name,
-				chapterId,
 				path: `${options.relativePath}/${name}`, // don't use path.join, it's os specific
 			});
 			if (mode.contentMode === LoadContentModes.FULL) {
@@ -185,7 +183,7 @@ export function loadContentFolder(
 
 class ParsedPageData implements IParsedPageData {
 	/* eslint-disable @typescript-eslint/no-explicit-any */
-	constructor(data: any) {
+	constructor(data: Partial<IParsedPageData>) {
 		Object.keys(this).forEach((key) => {
 			if (data[key] !== undefined) {
 				this[key] = data[key];

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,17 +4,18 @@ import { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import { AppContext } from "../contexts";
 import { fontFaceDecls } from "../site-fonts";
+import { IPageProps } from "../interfaces/models";
 
 export { reportWebVitals } from "next-axiom";
 
-const App = ({ Component, pageProps }: AppProps) => {
+const App = ({ Component, pageProps }: AppProps<IPageProps>) => {
 	const router = useRouter();
 	const fontStyles = css`
 		${fontFaceDecls}
 	`;
 
 	return (
-		<AppContext router={router}>
+		<AppContext router={router} documentPath={pageProps.documentPath}>
 			<style jsx global>
 				{fontStyles}
 			</style>

--- a/src/pages/posts.tsx
+++ b/src/pages/posts.tsx
@@ -22,7 +22,7 @@ export default function Blog(props: IPageProps) {
 				<h1 className={classes.title}>{sectionName}</h1>
 				{orderBy(pageData, ["metaData.date"], ["desc"]).map(
 					(page: IParsedPageData) => {
-						const { metaData, path } = page;
+						const { metaData, path: path } = page;
 						const { title, date, author } = metaData;
 						return (
 							<Post


### PR DESCRIPTION
Allows providing the correct document context even when the doc path doesn't match the route.