### PR TITLE
Page Parse Mode in Metadata

### DIFF
--- a/public/content/docs/the-story-of-mel/codex/index.en.md
+++ b/public/content/docs/the-story-of-mel/codex/index.en.md
@@ -2,6 +2,7 @@
 title: "The Story of Mel"
 moto: "This was posted to Usenet by its author, Ed Nather <nather@astro.as.utexas.edu>, on May 21, 1983:"
 credits: "Annotations written and curated by Tomer Lichtash and David Frenkiel"
+parse_mode: "verse"
 ---
 
 A recent article devoted to the _macho_ side of programming[^](annotations/recent-article)

--- a/public/content/docs/the-story-of-mel/codex/index.he.md
+++ b/public/content/docs/the-story-of-mel/codex/index.he.md
@@ -3,6 +3,7 @@ title: "הסיפור על מל"
 moto: "פורסם בידי מחברו, אד ניית׳ר <nather@astro.as.utexas.edu>, ברשת Usenet, ב-21 במאי 1983:"
 author: "אד ניית׳ר"
 credits: "תרגם מאנגלית וביאר: תומר ליכטש | ייעוץ מדעי: דוד פרנקל"
+parse_mode: "verse"
 ---
 
 מאמר מן הזמן האחרון על צד _מצ'ואיסטי_ בתכנות[^](annotations/recent-article)

--- a/src/interfaces/models.ts
+++ b/src/interfaces/models.ts
@@ -1,5 +1,6 @@
 import { IComponentKeyProps } from "../locales/keymap/types";
 import { DynamicContentTypes } from "./dynamic-content";
+import { MLParseModes } from "./parser";
 
 /**
  * Workaround for any
@@ -205,6 +206,8 @@ export interface IPageMetaData {
 	 * figures configuration, which may be overridden by the document metadata
 	 */
 	readonly figures: IFigureConfiguration;
+
+	readonly parse_mode?: MLParseModes;
 }
 
 /**

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -19,6 +19,8 @@ export enum LoadContentModes {
 }
 
 export enum MLParseModes {
+	// value must be falsy
+	AUTO = "",
 	VERSE = "verse",
 	NORMAL = "normal",
 }
@@ -71,16 +73,16 @@ export interface IContentParseOptions {
 	 */
 	readonly contentMode: LoadContentModes;
 	/**
+	 * The locale for which this content is parsed
+	 */
+	readonly locale: string;
+	 /**
 	 * Defaults to NORMAL
 	 */
-	readonly parseMode: MLParseModes;
+	readonly parseMode?: MLParseModes;
 	/**
 	 * an optional function that may return a new node
 	 */
 	readonly nodeProcessors?: Array<MLNodeProcessorFunction>;
 
-	/**
-	 * The locale for which this content is parsed
-	 */
-	readonly locale: string;
 }

--- a/src/lib/markdown-driver.ts
+++ b/src/lib/markdown-driver.ts
@@ -65,7 +65,7 @@ export interface ILoadContentOptions {
  */
 const DEFAULT_PARSE_OPTIONS: IContentParseOptions = {
 	contentMode: LoadContentModes.FULL,
-	parseMode: MLParseModes.NORMAL,
+	parseMode: MLParseModes.AUTO,
 	nodeProcessors: undefined,
 	locale: undefined,
 };
@@ -223,6 +223,8 @@ class PageMetaData implements IPageMetaData {
 	public source_url = "";
 	public source_name = "";
 	public source_author = "";
+	// value must be falsy, so initially it doesn't affect the parse mode computation
+	public parse_mode =  MLParseModes.AUTO; 
 	public figures: IFigureConfiguration = {
 		auto: true,
 		base: 1,

--- a/src/pages/api/content.ts
+++ b/src/pages/api/content.ts
@@ -3,7 +3,6 @@ import { CONTENT_TYPES } from "../../consts";
 import { mlApiUtils } from "../../lib/api-utils";
 import {
 	LoadContentModes,
-	MLParseModes,
 	LoadFolderModes,
 } from "../../interfaces/parser";
 import {
@@ -121,7 +120,6 @@ async function loadContent(
 			loadMode: LoadFolderModes.CHILDREN,
 			mode: {
 				contentMode: LoadContentModes.FULL,
-				parseMode: MLParseModes.NORMAL,
 				nodeProcessors: [contentUtils.createPopoverLinksMappingFilter()],
 			},
 			rootFolder: process.cwd(),

--- a/src/pages/docs/[id]/codex/index.tsx
+++ b/src/pages/docs/[id]/codex/index.tsx
@@ -7,7 +7,6 @@ import { GenericPage } from "../../../../components/content";
 import {
 	LoadContentModes,
 	LoadFolderModes,
-	MLParseModes,
 } from "../../../../interfaces/parser";
 
 export default function Doc(props: IPageProps) {
@@ -27,7 +26,6 @@ export const getStaticProps: GetStaticProps = async (
 		LoadFolderModes.FOLDER,
 		{
 			contentMode: LoadContentModes.FULL,
-			parseMode: MLParseModes.VERSE,
 			nodeProcessors: [contentUtils.createPopoverLinksMappingFilter()],
 		}
 	);

--- a/src/pages/docs/[id]/codex/pages/[pageId]/index.tsx
+++ b/src/pages/docs/[id]/codex/pages/[pageId]/index.tsx
@@ -6,7 +6,6 @@ import { GenericPage } from "../../../../../../components/content";
 import {
 	LoadContentModes,
 	LoadFolderModes,
-	MLParseModes,
 } from "../../../../../../interfaces/parser";
 
 export default function Doc(props: IPageProps) {
@@ -35,7 +34,6 @@ export const getStaticProps: GetStaticProps = async (
 		LoadFolderModes.FOLDER,
 		{
 			contentMode: LoadContentModes.FULL,
-			parseMode: MLParseModes.VERSE,
 			nodeProcessors: [contentUtils.createPopoverLinksMappingFilter()],
 		}
 	);

--- a/src/pages/docs/[id]/index.tsx
+++ b/src/pages/docs/[id]/index.tsx
@@ -7,7 +7,6 @@ import { GenericPage } from "../../../components/content";
 import {
 	LoadContentModes,
 	LoadFolderModes,
-	MLParseModes,
 } from "../../../interfaces/parser";
 
 export default function Doc(props: IPageProps) {
@@ -27,7 +26,6 @@ export const getStaticProps: GetStaticProps = async (
 		LoadFolderModes.FOLDER,
 		{
 			contentMode: LoadContentModes.FULL,
-			parseMode: MLParseModes.VERSE,
 			nodeProcessors: [contentUtils.createPopoverLinksMappingFilter()],
 		}
 	);

--- a/src/pages/docs/[id]/pages/[pageId]/index.tsx
+++ b/src/pages/docs/[id]/pages/[pageId]/index.tsx
@@ -6,7 +6,6 @@ import { GenericPage } from "../../../../../components/content";
 import {
 	LoadContentModes,
 	LoadFolderModes,
-	MLParseModes,
 } from "../../../../../interfaces/parser";
 
 export default function Doc(props: IPageProps) {
@@ -34,7 +33,6 @@ export const getStaticProps: GetStaticProps = async (
 		LoadFolderModes.FOLDER,
 		{
 			contentMode: LoadContentModes.FULL,
-			parseMode: MLParseModes.NORMAL,
 			nodeProcessors: [contentUtils.createPopoverLinksMappingFilter()],
 		}
 	);

--- a/src/pages/docs/[id]/resources/index.tsx
+++ b/src/pages/docs/[id]/resources/index.tsx
@@ -6,7 +6,6 @@ import { GenericPage } from "../../../../components/content";
 import {
 	LoadContentModes,
 	LoadFolderModes,
-	MLParseModes,
 } from "../../../../interfaces/parser";
 
 export default function Doc(props: IPageProps) {
@@ -35,7 +34,6 @@ export const getStaticProps: GetStaticProps = async (
 		LoadFolderModes.FOLDER,
 		{
 			contentMode: LoadContentModes.FULL,
-			parseMode: MLParseModes.VERSE,
 			nodeProcessors: [contentUtils.createPopoverLinksMappingFilter()],
 		}
 	);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,6 @@ import { mlNextUtils } from "../lib/next-utils";
 import {
 	LoadContentModes,
 	LoadFolderModes,
-	MLParseModes,
 } from "../interfaces/parser";
 import { contentUtils } from "../lib/content-utils";
 import { usePageData } from "../components/usePageData";
@@ -60,7 +59,6 @@ export const getStaticProps: GetStaticProps = async (context) => {
 		LoadFolderModes.FOLDER,
 		{
 			contentMode: LoadContentModes.FULL,
-			parseMode: MLParseModes.VERSE,
 			nodeProcessors: [contentUtils.createPopoverLinksMappingFilter()],
 		}
 	);


### PR DESCRIPTION
page components no longer need to specify the page's parse mode (verse or normal). They still can.