### PR TITLE
Add missing parenthesis

### DIFF
--- a/public/content/docs/the-story-of-mel/pages/mel-kaye-cv/index.en.md
+++ b/public/content/docs/the-story-of-mel/pages/mel-kaye-cv/index.en.md
@@ -96,7 +96,7 @@ A few handwritten code fragments, probably in his own handwriting, survived from
 </figure>
 
 <figure>
-![]https://mels-loop-media.s3.eu-north-1.amazonaws.com/mel-kaye-code-evaluation-of-4th-degree-polynomial-fixed-point-june-16th-1959-source-_lgp-30-subroutine-manual-oct-60_wgoukq.jpg)
+![](https://mels-loop-media.s3.eu-north-1.amazonaws.com/mel-kaye-code-evaluation-of-4th-degree-polynomial-fixed-point-june-16th-1959-source-_lgp-30-subroutine-manual-oct-60_wgoukq.jpg)
 
 <figcaption>Evaluation of 4th Degree Polynomial Fixed Point, June 1959, Signed by Mel Kaye</figcaption>
 </figure>


### PR DESCRIPTION
Missing parenthesis caused the image to display a raw link instead of rendering the image.