### PR TITLE
Make a quoted email one figure

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -89,7 +89,19 @@ export default async function Layout({
 	const navItems = buildNavItems(storySlug, articles);
 
 	const content = (
-		<html lang={locale} dir={dir} suppressHydrationWarning>
+		/*
+		 * The font variables belong on <html>, not <body>: the design tokens
+		 * that read them are declared at :root, and custom properties inherit
+		 * downwards only. Set on <body> they were invisible to :root, so every
+		 * token fell through to its literal-name fallback and lost next/font's
+		 * metric-matched fallback face with it.
+		 */
+		<html
+			lang={locale}
+			dir={dir}
+			className={`${robotoSlab.variable} ${hebrew.variable} ${lekton.variable}`}
+			suppressHydrationWarning
+		>
 			<head>
 				<link
 					rel="icon"
@@ -104,9 +116,7 @@ export default async function Layout({
 				<ColorSchemeScript />
 				<ScrollbarWidthScript />
 			</head>
-			<body
-				className={`${robotoSlab.variable} ${hebrew.variable} ${lekton.variable}`}
-			>
+			<body>
 				{gaId && <GoogleAnalytics gaId={gaId} />}
 				<PageScrollbar />
 				{/* Radix reads the direction from context, not from the document,

--- a/apps/web/src/components/layout/LocaleSwitcher/LocaleSwitcher.module.css
+++ b/apps/web/src/components/layout/LocaleSwitcher/LocaleSwitcher.module.css
@@ -14,7 +14,7 @@
 }
 
 .en {
-	font-family: var(--font-roboto-slab, var(--ml-font-latin));
+	font-family: var(--ml-font-latin);
 }
 
 /*
@@ -22,5 +22,5 @@
  * group's sm, so the two halves of one control were 16px and 12px.
  */
 .he {
-	font-family: var(--font-hebrew, var(--ml-font-hebrew));
+	font-family: var(--ml-font-hebrew);
 }

--- a/apps/web/src/content/renderer/core/ContentRenderer.module.css
+++ b/apps/web/src/content/renderer/core/ContentRenderer.module.css
@@ -98,25 +98,37 @@
 	display: grid;
 	grid-template-columns: auto 1fr;
 	gap: 0 var(--ml-space-md);
-	margin-bottom: var(--ml-space-lg);
+	margin: 0;
 	padding: var(--ml-space-md);
 	background-color: var(--ml-color-surface-subtle);
-	/* border-radius: var(--ml-radius-md); */
-	font-family: var(--ml-font-family-mono);
+	font-family: var(--ml-font-mono);
 	font-size: var(--ml-font-size-sm);
 	line-height: var(--ml-line-height-relaxed);
 	border: 1px solid var(--ml-border-color);
+	border-radius: var(--ml-radius-md) var(--ml-radius-md) 0 0;
 }
 
+/*
+ * The labels are the form, not the content — FROM, DATE, TO say nothing a
+ * reader came for. They recede so the addresses and the message beside them
+ * carry the full text colour, which is where the eye should land. Bold and
+ * uppercase still hold the column; only the weight of colour changes.
+ */
 .root dl[data-type='email-header'] dt {
 	font-weight: var(--ml-font-weight-bold);
-	color: var(--ml-text-color);
+	color: var(--ml-text-subtle-color);
 	text-transform: uppercase;
 }
 
+/*
+ * The values carry the message's own facts — who wrote, when, to whom — so
+ * they read at the same size and colour as the message below, and darker than
+ * the labels naming them.
+ */
 .root dl[data-type='email-header'] dd {
 	margin: 0;
-	color: var(--ml-text-subtle-color);
+	font-size: var(--ml-font-size-body);
+	color: var(--ml-text-color);
 }
 
 /* Chat (div[data-type="chat"]) */
@@ -162,12 +174,68 @@
 	 * anything too long for the column.
 	 */
 	white-space: pre-line;
-	padding: var(--ml-space-md) var(--ml-space-lg);
-	border-inline-start: 3px solid var(--ml-border-color);
-	background-color: var(--ml-color-surface-subtle);
-	border-radius: var(--ml-radius-md);
-	font-family: var(--ml-font-family-mono);
+	margin: 0;
+	padding: var(--ml-space-md);
+	font-family: var(--ml-font-mono);
 	font-size: var(--ml-font-size-sm);
+	border: 1px solid var(--ml-border-color);
+	border-radius: 0 0 var(--ml-radius-md) var(--ml-radius-md);
+}
+
+/*
+ * The message's paragraphs come through Text's body1 variant, which sets its
+ * own family, size and leading — so the box's monospace stopped at the
+ * container and the text inside it was still prose. The same trap as the
+ * font-size note further up this file.
+ *
+ * Justification goes with it: an email is written in short deliberate lines,
+ * and stretching them to a flush edge is the opposite of quoting it faithfully.
+ */
+.root div[data-type='email-body'] p {
+	font-family: var(--ml-font-mono);
+	/*
+	 * A step up from the header's labels. Lekton is a light face and sets
+	 * thin at 12px, which read as grey rather than as text — the message is
+	 * the thing being quoted and should be as readable as the prose around it.
+	 */
+	font-size: var(--ml-font-size-body);
+	line-height: var(--ml-line-height-relaxed);
+	color: var(--ml-text-color);
+	text-align: start;
+	hyphens: manual;
+}
+
+/*
+ * The message's last paragraph carries the prose bottom margin, which stacked
+ * on the box's own padding and left the space beneath the sign-off twice what
+ * sits above the greeting.
+ */
+.root div[data-type='email-body'] > :last-child {
+	margin-bottom: 0;
+}
+
+/*
+ * A quoted email, as one object.
+ *
+ * The header and the message used to be two separately bordered blocks with a
+ * gap between them, which read as two unrelated notes rather than as one
+ * piece of correspondence. They are now a single box: the header is its
+ * masthead, the message is the sheet below it, and the seam between them is
+ * one shared line rather than two adjacent borders.
+ */
+.root figure[data-type='email'] {
+	margin: 0 0 var(--ml-space-lg);
+	/*
+	 * The Figure primitive centres its contents, which suits an image narrower
+	 * than the column and ruins a block of text: the headers and the message
+	 * were centred inside their own box. Only the caption keeps the figure's
+	 * own alignment, which it sets for itself.
+	 */
+	text-align: start;
+}
+
+.root figure[data-type='email'] dl[data-type='email-header'] {
+	border-bottom: none;
 }
 
 /*

--- a/content/stories/the-story-of-mel/articles/mel-kaye-cv/index.en.md
+++ b/content/stories/the-story-of-mel/articles/mel-kaye-cv/index.en.md
@@ -108,6 +108,7 @@ Mel never sought (or even acknowledged) his glory in the hacking culture. In fac
 
 Thus wrote Anthony Cuozzo on April 2012:
 
+::::email
 :::email-header
 From: Anthony Cuozzo (acuozzo@\*\*\*.\*\*\*\*\*\*\*\*.\*\*\*)
 Date: Tue, Apr 17, 2012 at 10:59 AM
@@ -119,11 +120,14 @@ Hello Mel,
 Did you once work for Librascope Inc. or Royal McBee?
 Thanks,
 Anthony
-::cite[Anthony Cuozzo's email to Mel Kaye, 2012]
 :::
+
+::cite[Anthony Cuozzo's email to Mel Kaye, 2012]
+::::
 
 Within an hour, Mel replied:
 
+::::email
 :::email-header
 From: Mel Kaye (rimel3@roadrunner.com)
 Date: Tue, Apr 17, 2012 at 12:01 PM
@@ -134,7 +138,9 @@ To: acuozzo@\*\*\*.\*\*\*\*\*\*\*\*.\*\*\*
 Yes, I did, many, many years ago I worked for both of them.
 I believe I worked for Royal McBee first.
 Mel Kaye
-::cite[Mel's final email]
 :::
+
+::cite[Mel's final email]
+::::
 
 Upon receiving the reply, Cuozzo tried to continue the correspondence, but Mel fell silent. There are probably more chapters in this story. The research continues.

--- a/content/stories/the-story-of-mel/articles/mel-kaye-cv/index.he.md
+++ b/content/stories/the-story-of-mel/articles/mel-kaye-cv/index.he.md
@@ -105,6 +105,7 @@ date: Tue May 21 2023 01:00:00 GMT+0300
 
 וכך כתב אנתוני קוזו באפריל 2012:
 
+::::email
 :::email-header
 From: Anthony Cuozzo (acuozzo@\*\*\*.\*\*\*\*\*\*\*\*.\*\*\*)
 Date: Tue, Apr 17, 2012 at 10:59 AM
@@ -116,11 +117,14 @@ Hello Mel,
 Did you once work for Librascope Inc. or Royal McBee?
 Thanks,
 Anthony
-::cite[האימייל של אנתוני קוזו למל קיי, 2012.]
 :::
+
+::cite[האימייל של אנתוני קוזו למל קיי, 2012.]
+::::
 
 בתוך שעה, השיב מל:
 
+::::email
 :::email-header
 From: Mel Kaye (rimel3@roadrunner.com)
 Date: Tue, Apr 17, 2012 at 12:01 PM
@@ -131,7 +135,9 @@ To: acuozzo@\*\*\*.\*\*\*\*\*\*\*\*.\*\*\*
 Yes, I did, many, many years ago I worked for both of them.
 I believe I worked for Royal McBee first.
 Mel Kaye
-::cite[האימייל האחרון של מל]
 :::
+
+::cite[האימייל האחרון של מל]
+::::
 
 עם קבלת תשובתו של מייל ניסה קוזו להמשיך את ההתכתבות, אך קולו של מל נדם, והשתיקה נמשכת. זו, למעשה, היתה המילה האחרונה של מל.

--- a/libs/content-plugins/src/remark/email-directive.ts
+++ b/libs/content-plugins/src/remark/email-directive.ts
@@ -4,23 +4,31 @@ import { visit } from 'unist-util-visit';
 import type { DirectiveNode } from './types';
 
 /**
- * Email directives for presenting email-style content.
+ * Email directives for presenting quoted correspondence.
  *
- * `:::email-header` — Transforms into a definition list (`<dl>`) for
- * email metadata (Date, From, To, Subject, etc.).
+ * A quoted email is one thing, so it is authored as one: `::::email` wraps the
+ * header and body in a `<figure>`, which makes it a figure of the article like
+ * any photograph — numbered alongside them, and captioned by a `<figcaption>`
+ * that describes the message rather than being the last line of it.
  *
+ *   ::::email
  *   :::email-header
- *   Date: Wednesday, 3 September 1986  16:46-EDT
  *   From: Art Evans \<Evans@TL-20B.ARPA\>
+ *   Date: Wednesday, 3 September 1986  16:46-EDT
  *   To: Risks@CSL.SRI.COM
- *   Re: Always Mount a Scratch Monkey
  *   :::
- *
- * `:::email-body` — Wraps content in a styled container for email body text.
  *
  *   :::email-body
  *   In another forum that I follow...
  *   :::
+ *
+ *   ::cite[Art Evans to RISKS, 1986]
+ *   ::::
+ *
+ * The parts still work on their own — `:::email-header` is a definition list
+ * of the metadata, `:::email-body` a container for the message — but outside
+ * an `::::email` they are two unrelated blocks, which is what they looked
+ * like.
  */
 export function remarkEmailDirective() {
 	return (tree: Root) => {
@@ -29,7 +37,9 @@ export function remarkEmailDirective() {
 			const directive = node as DirectiveNode;
 			if (typeof index !== 'number' || !parent) return;
 
-			if (directive.name === 'email-header') {
+			if (directive.name === 'email') {
+				transformEmail(directive);
+			} else if (directive.name === 'email-header') {
 				transformEmailHeader(directive);
 			} else if (directive.name === 'email-body') {
 				directive.data = {
@@ -39,6 +49,27 @@ export function remarkEmailDirective() {
 			}
 		});
 	};
+}
+
+/**
+ * The wrapper: a `<figure>`, and its `::cite` becomes the `<figcaption>`.
+ *
+ * remarkBlockquoteDirective maps every `::cite` to a `<cite>`, and runs before
+ * this does — correct for an attribution inside a quotation, wrong for one
+ * describing a figure. Only a direct child is promoted, so a `::cite` deeper
+ * inside the message keeps its usual meaning.
+ */
+function transformEmail(directive: DirectiveNode) {
+	directive.data = {
+		hName: 'figure',
+		hProperties: { 'data-type': 'email' },
+	};
+
+	for (const child of directive.children) {
+		if (child.type === 'leafDirective' && child.name === 'cite') {
+			(child as DirectiveNode).data = { hName: 'figcaption' };
+		}
+	}
 }
 
 /**

--- a/libs/content-plugins/tests/remark/email-directive.test.ts
+++ b/libs/content-plugins/tests/remark/email-directive.test.ts
@@ -8,6 +8,45 @@ import { applyPlugins, findElements, textContent } from '../test-helpers';
 describe('remarkEmailDirective', () => {
 	const plugins: PluginSpec[] = [[remarkDirective], [remarkEmailDirective]];
 
+	describe('email', () => {
+		const md = [
+			'::::email',
+			':::email-header',
+			'From: Alice',
+			':::',
+			'',
+			':::email-body',
+			'Hello',
+			':::',
+			'',
+			'::cite[Alice to Bob, 1986]',
+			'::::',
+		].join('\n');
+
+		it('wraps the header and body in a figure', async () => {
+			const hast = await applyPlugins(md, { remarkPlugins: [...plugins] });
+			const figures = findElements(hast, 'figure');
+			expect(figures).toHaveLength(1);
+			expect(figures[0].properties?.['dataType']).toBe('email');
+			// both parts live inside it, rather than as loose siblings
+			expect(findElements(figures[0], 'dl')).toHaveLength(1);
+			expect(
+				findElements(figures[0], 'div').filter(
+					(d) => d.properties?.['dataType'] === 'email-body',
+				),
+			).toHaveLength(1);
+		});
+
+		it('promotes the citation to the figure caption', async () => {
+			const hast = await applyPlugins(md, { remarkPlugins: [...plugins] });
+			const captions = findElements(hast, 'figcaption');
+			expect(captions).toHaveLength(1);
+			expect(textContent(captions[0])).toBe('Alice to Bob, 1986');
+			// and it is no longer a <cite>, which is what a quotation would use
+			expect(findElements(hast, 'cite')).toHaveLength(0);
+		});
+	});
+
 	describe('email-header', () => {
 		it('converts :::email-header to a definition list', async () => {
 			const md = ':::email-header\nFrom: Alice\nTo: Bob\n:::';

--- a/packages/ui/src/primitives/Table/Table.module.css
+++ b/packages/ui/src/primitives/Table/Table.module.css
@@ -7,7 +7,7 @@
 	--ml-table-header-font-weight: var(--ml-font-weight-medium);
 	--ml-table-header-background-color: var(--ml-background-color-alt);
 	--ml-table-stripe-background-color: var(--ml-background-color-alt);
-	--ml-table-font-family-mono: var(--ml-font-family-mono);
+	--ml-table-font-family-mono: var(--ml-font-mono);
 }
 
 .root {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -7,7 +7,7 @@
 body {
 	background-color: var(--ml-background-color);
 	color: var(--ml-text-color);
-	font-family: var(--font-roboto-slab, var(--ml-font-latin));
+	font-family: var(--ml-font-latin);
 	font-size: var(--ml-font-size-body);
 	line-height: var(--ml-line-height-body);
 	-webkit-font-smoothing: antialiased;
@@ -15,7 +15,7 @@ body {
 }
 
 [dir='rtl'] body {
-	font-family: var(--font-hebrew, var(--ml-font-hebrew));
+	font-family: var(--ml-font-hebrew);
 }
 
 a {

--- a/packages/ui/src/styles/tokens/base/typography.css
+++ b/packages/ui/src/styles/tokens/base/typography.css
@@ -1,19 +1,30 @@
 /* ---- Typography ---- */
 
 :root {
-	/* Font Families */
-	--ml-font-latin: 'Roboto Slab', serif;
-	--ml-font-hebrew: 'Heebo', sans-serif;
 	/*
-	 * Lekton first, then the system stack. next/font self-hosts it — see
-	 * apps/web/src/fonts.ts — and it was being downloaded on every page while
-	 * nothing referenced it, because the token pointed at the system mono
-	 * instead. Named rather than read from --font-lekton so the package still
-	 * resolves outside the app, in Storybook.
+	 * ---- Font families ----
+	 *
+	 * Each reads next/font's variable first, then names the face literally,
+	 * then a generic.
+	 *
+	 * The variable is what matters: next/font serves each face from our own
+	 * origin *and* generates a metric-matched fallback beside it, so
+	 * --font-roboto-slab resolves to "Roboto Slab", "Roboto Slab Fallback".
+	 * Naming the family literally — which is what these tokens used to do —
+	 * skips that fallback, so text reflowed from a generic serif to the real
+	 * face on load rather than swapping between two faces of the same metrics.
+	 *
+	 * The literal name is kept as the var()'s fallback so the package still
+	 * resolves where next/font is absent, which is Storybook.
+	 *
+	 * apps/web/src/fonts.ts owns the other half of this: change a variable
+	 * name there and it must change here.
 	 */
+	--ml-font-latin: var(--font-roboto-slab, 'Roboto Slab'), serif;
+	--ml-font-hebrew: var(--font-hebrew, 'Heebo'), sans-serif;
 	--ml-font-mono:
-		'Lekton', ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas,
-		'DejaVu Sans Mono', monospace;
+		var(--font-lekton, 'Lekton'), ui-monospace, 'Cascadia Code',
+		'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 
 	/* Font Weights */
 	--ml-font-weight-light: 300;

--- a/packages/ui/src/styles/tokens/base/typography.css
+++ b/packages/ui/src/styles/tokens/base/typography.css
@@ -4,8 +4,15 @@
 	/* Font Families */
 	--ml-font-latin: 'Roboto Slab', serif;
 	--ml-font-hebrew: 'Heebo', sans-serif;
+	/*
+	 * Lekton first, then the system stack. next/font self-hosts it — see
+	 * apps/web/src/fonts.ts — and it was being downloaded on every page while
+	 * nothing referenced it, because the token pointed at the system mono
+	 * instead. Named rather than read from --font-lekton so the package still
+	 * resolves outside the app, in Storybook.
+	 */
 	--ml-font-mono:
-		ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas,
+		'Lekton', ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas,
 		'DejaVu Sans Mono', monospace;
 
 	/* Font Weights */


### PR DESCRIPTION
The two emails closing the CV article rendered as three loose pieces: a header block, a message block with a gap between them, and a citation sitting *inside* the message — so the archive's own words looked like the last line of what Cuozzo wrote.

They are now one object.

```html
<figure data-type="email" data-figure-index="20">
  <dl data-type="email-header">…</dl>
  <div data-type="email-body">…</div>
  <figcaption>20. Anthony Cuozzo's email to Mel Kaye, 2012</figcaption>
</figure>
```

`::::email` wraps both parts in a `<figure>`, which makes a quoted email a figure of the article like any photograph — **numbered alongside them** (Fig. 20 and Fig. 21 here) and described by a caption outside the box. A `::cite` directly inside becomes that caption; `remarkBlockquoteDirective` maps every `::cite` to a `<cite>` and runs first, which is right inside a quotation and wrong for one describing a figure, so this overrides it. Only a direct child is promoted.

The parts still work standalone — but outside a wrapper they were two unrelated blocks, which is exactly what they looked like.

## Design

One continuous box: the header rounds its top corners and drops its bottom edge, the message rounds the bottom, and they share a single seam (measured gap: 0).

Emphasis is inverted from where it started. `FROM` / `DATE` / `TO` are the form rather than the content, so they recede to the subtle colour while the addresses and the message take the full text colour a step up in size.

Padding is even — the last paragraph's prose margin had been stacking on the box's own, leaving twice the space beneath the sign-off as above the greeting.

## Bugs found on the way

**`--ml-font-family-mono` does not exist.** The real token is `--ml-font-mono`, so every declaration naming the former was silently dropped. Both email rules rendered in the prose serif, and **the Table primitive's mono variant has never worked at all.**

**Lekton was downloaded on every page and never used.** `next/font` self-hosts it — the built CSS carries its own `@font-face` and a metric-matched `Lekton Fallback`, with no request to `fonts.gstatic.com` — but no stylesheet referenced it. `--ml-font-mono` now leads with it, so `Code`, `CodeBlock`, tables and emails all get the face that was already being paid for.

**`Text`'s `body1` variant overrides its container's font-family**, not just size and leading as this file already documented. The box said monospace; the `<p>` inside said Roboto Slab and won.

**The `Figure` primitive centres its contents** — right for an image narrower than the column, wrong for a block of text, which was being centred inside its own box.

## Notes

The message body could not be darkened on its own: `--ml-text-color` already resolves to `--ml-gray-500`, the darkest value in the palette, and computed identical to the prose. What read as grey was Lekton setting thin at 12px — hence the size bump and the inverted emphasis.

Based on `mvp`, not `master`: `email-directive.ts` and the `:::email-header` content do not exist on `master`, so there would have been nothing to fix.

Verified by DOM geometry and built HTML in both locales — screenshots of this page time out on font loading, so a visual check before merge is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)