### PR TITLE
Put the custom scrollbar under the site header

### DIFF
--- a/apps/web/src/components/layout/PageScrollbar/PageScrollbar.module.css
+++ b/apps/web/src/components/layout/PageScrollbar/PageScrollbar.module.css
@@ -21,11 +21,21 @@
 			var(--ml-scroll-area-size, 8px) + 2 * var(--ml-scroll-area-gap, 4px)
 		);
 		/*
-		 * Above the sticky chrome — the header, story panel and tab strip all sit
-		 * below 100 — but under dialogs and popovers, which own the screen while
-		 * they are open.
+		 * Under the site header, over everything else.
+		 *
+		 * The thumb's grab target is 44px wide (see .thumb::before), which
+		 * reaches about 18px past this track and into the page. At 200 — above
+		 * the header's 100 — that strip covered the burger button at narrow
+		 * widths, where the burger sits close to the edge: elementFromPoint at
+		 * its centre returned the thumb, so the only navigation on a phone
+		 * could not be clicked at all.
+		 *
+		 * 95 keeps the thumb above the breadcrumb bar (90) and the tab strip
+		 * (89), so it stays visible while those are stuck to the top, and lets
+		 * the header take the clicks in its own row. Still under dialogs and
+		 * popovers, which own the screen while open.
 		 */
-		z-index: 200;
+		z-index: 95;
 		/* The track is only a rail; clicks belong to the page beneath it. */
 		pointer-events: none;
 	}


### PR DESCRIPTION
**The burger could not be clicked at phone widths.** The custom scrollbar was sitting on top of it.

```
390px   burger x 354–382   thumb hit area 360–404   click lands on: the thumb ✗
700px   burger x 664–692   thumb hit area 670–714   click lands on: the thumb ✗
1024px  burger x 959–991   thumb hit area 994–1038  click lands on: the burger ✓
1280px  ok                                          ✓
```

Two things combined. The thumb's grab target is **44px wide** — widened by `.thumb::before` for WCAG 2.5.5 — which reaches ~18px past the 16px track and into the page. And `.track` sat at `z-index: 200`, above the header's `100`. At narrow widths the burger sits close enough to the edge that the two overlap, and `elementFromPoint` at the button's centre returns the thumb.

On a phone the drawer is the *only* navigation, so this made the site unnavigable there.

**Why nobody caught it:** it depends on viewport width. From 1024px up there's enough chrome between the burger and the edge that they never meet, so it looks fine on a desktop.

## The fix

One line: `z-index: 200` → `95`.

Under the header (100) so the header owns its own row, but above the breadcrumb bar (90) and tab strip (89) so the thumb stays visible while those are stuck to the top. Still under dialogs and popovers, which own the screen while open.

## Verified

At 390, 700, 1024 and 1280: the burger receives the click at every width, a real click opens the drawer, and the thumb stays grabbable below the header band with `pointer-events: auto`.

Before this, a Playwright click on the burger failed with *"PageScrollbar thumb intercepts pointer events"* — the error that pointed at this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)