### PR TITLE
Initialise the content loaders inside the server actions

### DIFF
--- a/apps/web/src/actions/annotations.ts
+++ b/apps/web/src/actions/annotations.ts
@@ -1,5 +1,16 @@
 'use server';
 
+/*
+ * Initialises the loaders. Not optional, and not redundant with the layout.
+ *
+ * A Server Action is compiled into its own bundle, with its own instance of
+ * the loader module and no layout above it — so the layout's side-effect
+ * import never runs here. Without this the action threw "Content directory
+ * not set" in production while every page rendered fine, because pages are
+ * reached through a layout that does import it.
+ */
+import '../content-init';
+
 import {
 	getAllAnnotations,
 	getAllGlossaryTerms,

--- a/apps/web/src/actions/sources.ts
+++ b/apps/web/src/actions/sources.ts
@@ -1,5 +1,16 @@
 'use server';
 
+/*
+ * Initialises the loaders. Not optional, and not redundant with the layout.
+ *
+ * A Server Action is compiled into its own bundle, with its own instance of
+ * the loader module and no layout above it — so the layout's side-effect
+ * import never runs here. Without this the action threw "Content directory
+ * not set" in production while every page rendered fine, because pages are
+ * reached through a layout that does import it.
+ */
+import '../content-init';
+
 import { getResolvedSource } from '@mels-loop/content-loaders/loaders';
 
 import type { Locale } from '@/i18n-init';


### PR DESCRIPTION
Every popover on the deployed site failed. Clicking a glossary term or an annotation POSTs to a Server Action, and it returned 500:

```
Error: Content directory not set. Call setContentDir() before using loaders.
```

## Cause

A Server Action is compiled into its own bundle, with its own instance of the loader module and no layout above it — so the layout's `import '../content-init'` side effect never ran there. Pages were fine because a layout always renders before its page, and it does import it.

This is why it could not be caught locally: in development everything shares one module graph, so the layout's import initialises the loaders for the actions too. Only a production build splits them.

## Fix

Both action files now import `content-init` themselves. Pages are left alone — they are reached through the layout by construction.

## Verified on a preview deployment

Since the bug does not reproduce locally, this was checked against a real build:

| Path | Before | After |
|---|---|---|
| Glossary term, `/en/` | 500 | 200 — "Real Programmer", body populated |
| Glossary term, `/he/` | 500 | 200 — "מתכנתים אמיתיים", body populated |
| Annotation 1, `/en/` | 500 | 200 — Ed Post / Tektronix 1982, body populated |

Gates: lint 12/12, test 9/9, build 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)