### PR TITLE
Show the loader on the whole popover, not just its content

### DIFF
--- a/apps/web/src/content/popover/views/AnnotationPopover/AnnotationPopover.module.css
+++ b/apps/web/src/content/popover/views/AnnotationPopover/AnnotationPopover.module.css
@@ -11,11 +11,6 @@
 }
 
 /* Padding comes from the scroller — see --ml-popover-padding above. */
-.loader {
-	display: flex;
-	justify-content: center;
-}
-
 .body {
 	/* Size comes from the panel — see --ml-popover-font-size. */
 	line-height: var(--ml-line-height-body);

--- a/apps/web/src/content/popover/views/AnnotationPopover/AnnotationPopover.tsx
+++ b/apps/web/src/content/popover/views/AnnotationPopover/AnnotationPopover.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslation } from '@mels-loop/i18n/client';
-import { IndexMarker, Loader, Popover } from '@mels-loop/ui/primitives';
+import { IndexMarker, Popover } from '@mels-loop/ui/primitives';
 import { useMemo } from 'react';
 
 import { ContentRenderer } from '../../../renderer/core/ContentRenderer';
@@ -50,6 +50,7 @@ export function AnnotationPopover({
 				if (!next) closePopover();
 			}}
 			toolbar={<NavBar rootLabel={displayLabel} />}
+			loading={!displayContent}
 			title={`Annotation ${sequence}`}
 			side={side}
 			triggerRef={triggerRef}
@@ -69,11 +70,8 @@ export function AnnotationPopover({
 			 * the note itself down the panel. Once they navigate inward the
 			 * toolbar's trail names where they are; at the root it stays empty.
 			 */}
-			{!displayContent ? (
-				<div className={styles.loader}>
-					<Loader size="md" />
-				</div>
-			) : (
+			{/* The panel renders its own loader while this is null — see `loading`. */}
+			{displayContent && (
 				<>
 					<ContentRenderer
 						hast={displayContent.hast}

--- a/apps/web/src/content/popover/views/GlossaryPopover/GlossaryPopover.module.css
+++ b/apps/web/src/content/popover/views/GlossaryPopover/GlossaryPopover.module.css
@@ -133,12 +133,6 @@
 	color: var(--ml-text-color);
 }
 
-.loader {
-	display: flex;
-	justify-content: center;
-	padding: var(--ml-space-lg);
-}
-
 .body {
 	/* Size comes from the panel — see --ml-popover-font-size. */
 	line-height: var(--ml-line-height-body);

--- a/apps/web/src/content/popover/views/GlossaryPopover/GlossaryPopover.tsx
+++ b/apps/web/src/content/popover/views/GlossaryPopover/GlossaryPopover.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslation } from '@mels-loop/i18n/client';
-import { Loader, Popover } from '@mels-loop/ui/primitives';
+import { Popover } from '@mels-loop/ui/primitives';
 import { useMemo } from 'react';
 
 import { ContentRenderer } from '../../../renderer/core/ContentRenderer';
@@ -62,6 +62,7 @@ export function GlossaryPopover({
 				if (!next) closePopover();
 			}}
 			toolbar={<NavBar rootLabel={originalLabel} />}
+			loading={!displayContent}
 			title={originalLabel}
 			side={side}
 			triggerRef={triggerRef}
@@ -96,11 +97,8 @@ export function GlossaryPopover({
 					</p>
 				)}
 			</div>
-			{!displayContent ? (
-				<div className={styles.loader}>
-					<Loader size="md" />
-				</div>
-			) : (
+			{/* The panel renders its own loader while this is null — see `loading`. */}
+			{displayContent && (
 				<>
 					<ContentRenderer
 						hast={displayContent.hast}

--- a/apps/web/src/content/popover/views/SourcePopover/SourcePopover.module.css
+++ b/apps/web/src/content/popover/views/SourcePopover/SourcePopover.module.css
@@ -53,11 +53,6 @@
 }
 
 /* Padding comes from the scroller — see --ml-popover-padding above. */
-.loader {
-	display: flex;
-	justify-content: center;
-}
-
 /* Open: the fill is the indicator, so the rule underneath it is noise. */
 .trigger[data-state='open'] {
 	background-color: var(--ml-term-highlight);

--- a/apps/web/src/content/popover/views/SourcePopover/SourcePopover.tsx
+++ b/apps/web/src/content/popover/views/SourcePopover/SourcePopover.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Loader, Popover } from '@mels-loop/ui/primitives';
+import { Popover } from '@mels-loop/ui/primitives';
 
 import { SourceDetail } from '../../../sources/SourceDetail/SourceDetail';
 import { useContentPopover } from '../../hooks/useContentPopover';
@@ -39,6 +39,7 @@ export function SourcePopover({ id, label }: SourcePopoverProps) {
 				if (!next) closePopover();
 			}}
 			toolbar={<NavBar rootLabel={String(displayLabel)} />}
+			loading={!source}
 			title={id}
 			side={side}
 			triggerRef={triggerRef}
@@ -54,13 +55,8 @@ export function SourcePopover({ id, label }: SourcePopoverProps) {
 				</button>
 			}
 		>
-			{!source ? (
-				<div className={styles.loader}>
-					<Loader size="md" />
-				</div>
-			) : (
-				<SourceDetail source={source} />
-			)}
+			{/* The panel renders its own loader while this is null — see `loading`. */}
+			{source && <SourceDetail source={source} />}
 		</Popover>
 	);
 }

--- a/packages/ui/src/primitives/Popover/Popover.module.css
+++ b/packages/ui/src/primitives/Popover/Popover.module.css
@@ -181,6 +181,23 @@
 	);
 }
 
+/*
+ * The panel while its content is in flight — see the `loading` prop.
+ *
+ * One rule for both variants. In the sheet, whose height is fixed, flex: 1
+ * takes everything the bar leaves; in the anchored panel, whose height is its
+ * content, the min-height gives the loader a panel to sit in the middle of
+ * rather than a strip barely taller than the spinner.
+ */
+.loading {
+	display: flex;
+	flex: 1;
+	align-items: center;
+	justify-content: center;
+	min-height: 120px;
+	padding: var(--ml-space-lg);
+}
+
 /* ---- Mobile bottom sheet ---- */
 
 .sheetOverlay {

--- a/packages/ui/src/primitives/Popover/Popover.stories.tsx
+++ b/packages/ui/src/primitives/Popover/Popover.stories.tsx
@@ -57,3 +57,8 @@ export const Left: Story = {
 export const Top: Story = {
 	args: { side: 'top' },
 };
+
+/* Content still in flight: one indicator for the panel, no heading above it. */
+export const Loading: Story = {
+	args: { loading: true, defaultOpen: true },
+};

--- a/packages/ui/src/primitives/Popover/Popover.tsx
+++ b/packages/ui/src/primitives/Popover/Popover.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react';
 
 import { CloseButton } from '../CloseButton/CloseButton';
+import { Loader } from '../Loader/Loader';
 import { ScrollArea } from '../ScrollArea/ScrollArea';
 import styles from './Popover.module.css';
 
@@ -53,6 +54,21 @@ export interface PopoverProps {
 	 * stays put while the content moves under it.
 	 */
 	toolbar?: ReactNode;
+	/**
+	 * Replaces the whole panel body with a centred loader.
+	 *
+	 * The panel, not the content slot. Views used to render their own spinner
+	 * as `children`, which left their heading above it — so a term the reader
+	 * had just clicked was titled and framed while its definition was still in
+	 * flight, and the panel then resized underneath the finished text. One
+	 * indicator for the whole panel reads as "this is loading" rather than "this
+	 * has loaded, apart from the part you wanted".
+	 *
+	 * The toolbar stays. It is empty on a first open, so nothing shows there
+	 * anyway; once the reader has navigated inward it holds the trail and the
+	 * back control, and taking those away mid-navigation would strand them.
+	 */
+	loading?: boolean;
 	closeLabel?: string;
 	className?: string;
 }
@@ -82,6 +98,7 @@ export function Popover({
 	collisionPadding = 8,
 	title,
 	toolbar,
+	loading = false,
 	closeLabel = 'Close',
 	className,
 }: PopoverProps) {
@@ -191,6 +208,13 @@ export function Popover({
 		[onOpenChange],
 	);
 
+	/* Stands in for the scrolling body on both variants, so it is written once. */
+	const loadingBody = (
+		<div className={styles.loading}>
+			<Loader size="md" />
+		</div>
+	);
+
 	if (isMobile) {
 		return (
 			<RadixDialog.Root
@@ -237,13 +261,17 @@ export function Popover({
 								/>
 							</RadixDialog.Close>
 						</div>
-						<ScrollArea
-							type="auto"
-							className={styles.sheetScroll}
-							viewportClassName={styles.sheetViewport}
-						>
-							{children}
-						</ScrollArea>
+						{loading ? (
+							loadingBody
+						) : (
+							<ScrollArea
+								type="auto"
+								className={styles.sheetScroll}
+								viewportClassName={styles.sheetViewport}
+							>
+								{children}
+							</ScrollArea>
+						)}
 					</RadixDialog.Content>
 				</RadixDialog.Portal>
 			</RadixDialog.Root>
@@ -288,13 +316,17 @@ export function Popover({
 							/>
 						</RadixPopover.Close>
 					</div>
-					<ScrollArea
-						type="auto"
-						className={styles.scrollArea}
-						viewportClassName={styles.scrollViewport}
-					>
-						{children}
-					</ScrollArea>
+					{loading ? (
+						loadingBody
+					) : (
+						<ScrollArea
+							type="auto"
+							className={styles.scrollArea}
+							viewportClassName={styles.scrollViewport}
+						>
+							{children}
+						</ScrollArea>
+					)}
 					<RadixPopover.Arrow className={styles.arrow} width={14} height={7} />
 				</RadixPopover.Content>
 			</RadixPopover.Portal>


### PR DESCRIPTION
On a first open the panel drew its finished chrome around a spinner: the glossary popover rendered its kicker and the term's title, then a small spinner where the definition would go. It read as "this has loaded, apart from the part you wanted" — and the panel then resized under the reader once the real text arrived.

## Change

`loading` is now a prop on the `Popover` primitive, which swaps the entire body — heading included — for one centred indicator. All three views get the same behaviour from one place instead of each rendering its own spinner as `children`.

The toolbar deliberately stays. `NavBar` returns `null` while the nav stack is empty, so on a first open there is nothing there to see anyway; once the reader has navigated inward it holds the trail and the back control, and removing those mid-navigation would strand them with only a close button.

One CSS rule covers both variants: `flex: 1` fills the sheet, whose height is fixed, and the `min-height` gives the anchored panel a body to centre the loader in rather than a strip barely taller than the spinner.

The three views lose their own loader branches and their now-dead `.loader` rules. `Popover` gains a `Loading` story.

## Caveat

**Not verified visually.** The state lasts ~50ms against a warm action, and reproducing it needs a throttled server. The logic is a straight prop swap and the gates pass, but nobody has watched it render.

Gates: lint 12/12, test 9/9, build 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)