### PR TITLE
Route the story avatar through the image optimiser

### DIFF
--- a/apps/web/src/components/stories/StoryHeader/StoryHeader.tsx
+++ b/apps/web/src/components/stories/StoryHeader/StoryHeader.tsx
@@ -1,7 +1,18 @@
 import { Avatar, Text } from '@mels-loop/ui/primitives';
+import NextImage from 'next/image';
 
 import { StoryIdentityLink } from '../StoryTitle/StoryTitle';
 import styles from './StoryHeader.module.css';
+
+/*
+ * The avatar's widest rendering — 6rem at Avatar's xl size. Mobile draws it at
+ * 56px and simply scales this down, which is cheaper than a second request.
+ *
+ * next/image builds the srcset from this, so the browser fetches roughly 1.5 KB
+ * at 1x and 5 KB at 2x. Left to the plain <img> the primitive renders from
+ * `src`, it fetched the 2 MB original instead.
+ */
+const AVATAR_PX = 96;
 
 interface StoryHeaderProps {
 	title: string;
@@ -26,7 +37,16 @@ export function StoryHeader({
 				<StoryIdentityLink href={`/stories/${storySlug}`}>
 					{(avatarSrc || avatarFallback) && (
 						<Avatar
-							src={avatarSrc}
+							image={
+								avatarSrc && (
+									<NextImage
+										src={avatarSrc}
+										alt={avatarAlt ?? ''}
+										width={AVATAR_PX}
+										height={AVATAR_PX}
+									/>
+								)
+							}
 							alt={avatarAlt}
 							fallback={avatarFallback}
 							size="xl"

--- a/content/stories/the-story-of-mel/story.json
+++ b/content/stories/the-story-of-mel/story.json
@@ -26,7 +26,7 @@
 		"cover": "source:mel-kaye-photo-1952",
 		"thumbnail": "source:mel-kaye-photo-1952",
 		"avatar": {
-			"src": "source:mel-kaye-photo-1952",
+			"src": "/media/v2/images/mel-kaye-1952-avatar.jpg",
 			"initials": "avatar.initials",
 			"alt": "avatar.alt"
 		}

--- a/packages/ui/src/primitives/Avatar/Avatar.module.css
+++ b/packages/ui/src/primitives/Avatar/Avatar.module.css
@@ -52,6 +52,34 @@
 	opacity: 1;
 }
 
+/*
+ * Wrapper for a caller-supplied image element — see the `image` prop.
+ *
+ * The element inside is the app's, not ours, so it is shaped by descendant
+ * selector rather than by a class we would have to graft onto it.
+ */
+.imageSlot {
+	display: block;
+	width: 100%;
+	height: 100%;
+	/* Carries the circle down to the image. Without it the chain stops here —
+	 * the root is round, this wrapper is not, and `inherit` on the image below
+	 * resolves against this rather than the root. */
+	border-radius: inherit;
+}
+
+/*
+ * next/image sets width and height as HTML attributes rather than inline
+ * styles, and those are presentational hints — any author rule outranks them,
+ * so this needs no !important to fill the circle.
+ */
+.imageSlot img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	border-radius: inherit;
+}
+
 .loader {
 	position: absolute;
 }

--- a/packages/ui/src/primitives/Avatar/Avatar.tsx
+++ b/packages/ui/src/primitives/Avatar/Avatar.tsx
@@ -2,7 +2,7 @@
 
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 import cn from 'classnames';
-import { type HTMLAttributes, useRef, useState } from 'react';
+import { type HTMLAttributes, type ReactNode, useRef, useState } from 'react';
 
 import { Loader } from '../Loader/Loader';
 import styles from './Avatar.module.css';
@@ -14,6 +14,26 @@ export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
 	alt?: string;
 	fallback?: string;
 	size?: AvatarSize;
+	/**
+	 * A ready-made image element, rendered instead of the plain `<img>` that
+	 * `src` produces. Takes precedence over `src`.
+	 *
+	 * This exists so an app can hand in a framework's optimising image
+	 * component — `next/image`, say — without this package taking a dependency
+	 * on that framework. The story header did exactly that: a 2 MB portrait
+	 * downloaded in full to fill a 92px circle, on every page of the story,
+	 * because the avatar was the one image on the site that never reached the
+	 * image optimiser.
+	 *
+	 * A slot rather than `asChild`, which looks like the obvious answer and is
+	 * not: `AvatarPrimitive.Image` tracks loading by calling
+	 * `new window.Image()` with the `src` it is given, so the original would
+	 * still be fetched no matter what the child rendered. The slot skips that
+	 * component altogether, and with it Radix's fade-in and loader — neither of
+	 * which an optimised image needs, since it arrives in a few kilobytes and
+	 * brings its own placeholder handling.
+	 */
+	image?: ReactNode;
 }
 
 export function Avatar({
@@ -21,6 +41,7 @@ export function Avatar({
 	alt,
 	fallback,
 	size = 'md',
+	image,
 	className,
 	...props
 }: AvatarProps) {
@@ -55,7 +76,8 @@ export function Avatar({
 			)}
 			{...props}
 		>
-			{src && (
+			{image && <span className={styles.imageSlot}>{image}</span>}
+			{!image && src && (
 				<>
 					<AvatarPrimitive.Image
 						className={cn(styles.image, {
@@ -77,7 +99,7 @@ export function Avatar({
 					)}
 				</>
 			)}
-			{!src && (
+			{!image && !src && (
 				<AvatarPrimitive.Fallback className={styles.fallback}>
 					{initials}
 				</AvatarPrimitive.Fallback>


### PR DESCRIPTION
The avatar was the one image on the site that never reached `next/image`. It rendered a **1114x1412, 2 MB portrait into a 92px circle** — and because the story header lives in the layout, on the landing page and every article too. It was the heaviest asset on all of them.

| | before | after |
|---|---|---|
| avatar request | 2063 KB PNG | **1.5 KB** webp |
| all images on the page | 2064 KB | **2.5 KB** |
| avatar decode size | 1114x1412 | 96x96 |

## Why a slot and not `asChild`

`Avatar` renders Radix's `AvatarPrimitive.Image`, a plain `<img>`. `packages/ui` has no `next` dependency and no `next/*` imports anywhere, so reaching the optimiser by importing `next/image` there would make a framework-agnostic package framework-bound.

`asChild` looks like the obvious alternative and does not work. From the Radix source:

```js
const imageLoadingStatus = useImageLoadingStatus(src, imageProps);
...
imageRef.current = new window.Image();
image.src = src;
```

It preloads by constructing a `new window.Image()` from the `src` it is given — so the 2 MB original would still be fetched regardless of what the child rendered. The slot skips that component entirely, and with it Radix's fade-in and spinner, neither of which an optimised image needs.

## A dedicated crop

`next/image` resizes but cannot crop. A circle showing a square region of a portrait was picking that region blindly through `object-fit: cover`. `mel-kaye-1952-avatar.jpg` is a deliberate 512x512 crop framed on the face, bow tie and shoulders in view.

Its `src` is a direct path rather than a `source:` reference — the avatar is UI furniture, not a citable source. `cover` and `thumbnail` still cite `mel-kaye-photo-1952`.

## Verified

Production build, both locales: 96x96 natural, `border-radius: 50%`, `object-fit: cover`, 2.5 KB total page images.

Gates: lint 12/12, test 9/9, build 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)