### PR TITLE
Open the lightbox at full resolution

### DIFF
--- a/apps/web/src/components/content/ImageViewer/ImageViewer.tsx
+++ b/apps/web/src/components/content/ImageViewer/ImageViewer.tsx
@@ -17,6 +17,35 @@ const LightboxModal = dynamic(() => import('./LightboxModal'), { ssr: false });
 const ZOOMABLE = 'img[data-zoomable]';
 
 /**
+ * Width the lightbox asks the image optimiser for.
+ *
+ * Must be one of next/image's configured widths — an unlisted value is
+ * rejected with a 400, not rounded to the nearest. 1920 is in the default
+ * deviceSizes and sits above the 2000px ceiling the masters are stored at, so
+ * it is the most the optimiser can actually produce for them.
+ */
+const LIGHTBOX_WIDTH = 1920;
+
+/**
+ * The article's derivative, re-requested at lightbox size.
+ *
+ * Slides used to carry `currentSrc` straight from the page, which meant the
+ * lightbox displayed the same file the column did — 750px — and the zoom
+ * plugin magnified those pixels rather than revealing any. On an archive whose
+ * images are census forms, punch printouts and coding sheets, zooming into a
+ * primary source showed nothing that reading the caption had not.
+ *
+ * Only the width parameter changes, so the optimiser treats it as a separate
+ * derivative and caches it as one. Anything that is not an optimiser URL — an
+ * SVG, an unoptimised remote host — has no `w=` to rewrite and is returned
+ * untouched.
+ */
+function lightboxSrc(src: string): string {
+	if (!src.includes('/_next/image')) return src;
+	return src.replace(/([?&]w=)\d+/, `$1${LIGHTBOX_WIDTH}`);
+}
+
+/**
  * Provenance for an image drawn from the source registry.
  *
  * rehypeSourceImages already writes the author, credit and licence onto the
@@ -52,7 +81,7 @@ function toSlide(el: HTMLImageElement): ViewerSlide {
 	const credit = provenance(el);
 
 	return {
-		src: el.currentSrc || el.src,
+		src: lightboxSrc(el.currentSrc || el.src),
 		alt: el.alt || '',
 		title: caption,
 		/*


### PR DESCRIPTION
Slides carried `currentSrc` straight off the page, so the lightbox displayed **the same 750px derivative the article column did**, and the zoom plugin magnified those pixels rather than revealing any. On an archive whose images are census forms, punch printouts and signed coding sheets, zooming into a primary source showed nothing that reading the caption had not.

## Change

The slide's `src` is the same optimiser URL with its width parameter raised. Only that parameter changes, so the optimiser treats it as its own derivative and caches it as one — requested when a reader opens an image, not with the page.

`1920` because it must be one of `next/image`'s configured widths (an unlisted value is rejected with a **400**, not rounded — I hit that with `w=192` while testing), and because it sits above the 2000px ceiling the masters are stored at, so it is the most the optimiser can produce for them.

Anything without a `w=` to rewrite — an SVG, an unoptimised host — is returned untouched.

## Measured on the CV article

| | before | after |
|---|---|---|
| herman-kaye-naturalization-front | 750px wide | **1735x2000**, 379 KB |
| rita-kaye-naturalization-front | 750px wide | **1725x2000**, 408 KB |
| mel-kaye-restored-colorize | 750px wide | 1114x1412, 59 KB |

Paid only on open, only for images actually viewed. Zero 400s.

## Not addressed

Inline thumbnails render at 196px and still request 750. `Image.tsx` cannot tell which images are laid out small — that comes from CSS, not the element. A blanket `sizes` would fix the column case and leave thumbnails wrong; doing it properly needs per-image intent in the content.

Gates: lint 12/12, test 9/9, build 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)