### PR TITLE
Treat content/ as an input to the build

### DIFF
--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/content/**"]
+		}
+	}
+}

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
+			"inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/content/**"],
 			"outputs": [".next/**", "!.next/cache/**", "dist/**"]
 		},
 		"dev": {

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,6 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
-			"inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/content/**"],
 			"outputs": [".next/**", "!.next/cache/**", "dist/**"]
 		},
 		"dev": {


### PR DESCRIPTION
Turbo derives a task's cache key from files inside the package that owns it. `content/` sits at the repo root, outside every package, so a change there left the key untouched and `pnpm build` returned a **cache hit** — printing six successful tasks while emitting the previous content.

## Not theoretical

This happened while moving media references onto the new bucket prefix (#373). The build reported success; a crawl of the running server still showed every image on the old paths. The rewrite was correct — the build had simply not run.

In CI the same hit would ship stale content behind a green check.

## Fix

A package-level `apps/web/turbo.json` that extends the root config and overrides the one task:

```json
{
  "extends": ["//"],
  "tasks": {
    "build": {
      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/content/**"]
    }
  }
}
```

`$TURBO_ROOT$` addresses the repo root from a package-scoped input, so this stays on `build` rather than becoming a `globalDependency` that would also invalidate `lint`.

Scoped to `apps/web` rather than left on the root task: the root definition is inherited by every package, so a content edit invalidated all six builds including five libraries that never read content.

## Verified

```
unchanged tree     6 cached / 6 total
one source edited  @mels-loop/web:build: cache miss
                   5 cached / 6 total     ← only web re-runs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)