### PR TITLE
ci: verify main on push, not only in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
 on:
+  # The trunk is what deploys, so it is what has to be verified. Without this
+  # every check only ever ran on a PR head — a merge could produce a `main`
+  # nobody tested, and that `main` goes straight to production.
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
```yaml
on:
  push:
    branches: [main]     # ← added
  pull_request:
  workflow_dispatch:
```

The workflow triggered on `pull_request` and `workflow_dispatch` only, so **every check that has ever run did so against a PR head**. The trunk itself was never verified — and the trunk is what deploys.

That was survivable while `master` was a year-stale snapshot nobody merged into. It isn't now:

- `main` is live on melsloop.com
- merges land there continuously
- a squash, or a conflict resolution, can produce a tree no CI run ever saw — and it goes straight to production

Also a prerequisite for **Phase 1.1** (`FUTURE-PRS.md`): release-please triggers on push to `main`.

## Verification

This PR is its own test in one direction — the `pull_request` trigger still fires here. The `push` half only proves itself on merge, so the check is: after merging, a CI run should appear against `main` itself rather than only against the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)