### PR TITLE
ci: release only after CI passes, and stop gating production

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,13 +2,20 @@ name: Release
 
 # Maintains a single open "release PR" that bumps the version and rewrites
 # CHANGELOG.md from the conventional commits since the last release. Merging
-# that PR is what cuts a release: it tags vX.Y.Z, publishes a GitHub Release,
-# and — via the promote job below — moves production.
+# that PR tags vX.Y.Z and publishes a GitHub Release.
 #
-# Production follows the `production` branch, not `main`. So a merge to `main`
-# ships nothing on its own; only a release does.
+# It does not deploy, and deliberately so. Production follows `main` through
+# Vercel's git integration, so every merge ships — releases are a record of
+# what shipped, not a gate in front of it. See the note in FUTURE-PRS.md for
+# why the gate was designed and then dropped.
+#
+# Triggered by CI finishing on main rather than by the push itself. Those are
+# not the same thing: on `push` this raced CI, so a red trunk could still
+# produce a Release PR proposing to ship it.
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -18,36 +25,18 @@ permissions:
 
 jobs:
   release-please:
+    # workflow_run fires on failure too; only a green trunk may release.
+    # Always true for a manual workflow_dispatch, which has no upstream run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  promote:
-    # Only when a Release PR was merged — not on ordinary pushes to main.
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          # The full history, or the fast-forward check below has nothing to
-          # compare against.
-          fetch-depth: 0
-
-      - name: Fast-forward production to the release commit
-        # No event data is interpolated here — only refs this workflow controls.
-        run: |
-          set -euo pipefail
-          git push origin HEAD:production
-        # A non-fast-forward push fails, and that failure is the point: it means
-        # something reached `production` without going through a release, and
-        # the right response is to look rather than to force it.
+          # Explicit: under workflow_run this workflow runs in the context of
+          # the default branch rather than the branch that triggered it, so the
+          # target cannot be inferred from the ref.
+          target-branch: main


### PR DESCRIPTION
Two changes to the Release workflow, one of them a reversal of #381.

## 1. Release follows CI instead of racing it

It triggered on `push` to `main`, in parallel with CI — so a red trunk could still produce a Release PR proposing to ship it.

```yaml
on:
  workflow_run:
    workflows: [CI]
    types: [completed]
    branches: [main]
  workflow_dispatch:

    if: >-
      github.event_name == 'workflow_dispatch' ||
      github.event.workflow_run.conclusion == 'success'
```

`workflow_run` fires on failure too, hence the explicit conclusion check. `workflow_dispatch` still works — that's how the last release was regenerated after the `v2.0.0` tag was corrected.

One gotcha, handled: `workflow_run` executes in the context of the **default branch**, not the branch that triggered it, so release-please can't infer its target from the ref. Now passed explicitly as `target-branch: main`.

## 2. The production gate is removed before it was ever switched on

#381 added a `promote` job to fast-forward a `production` branch that Vercel would follow, so a merge to `main` would ship nothing by itself. It never went live, and on reflection it shouldn't.

**Batching enlarges the blast radius.** A gated release carries N merges, so a bad deploy means bisecting N changes instead of reading one. Shipping from `main` keeps "what changed" and "what broke" the same size.

**Rollback got worse, not better.** Every release is tagged, so the target is always known — but `git push origin HEAD:production` is fast-forward only, and fast-forward can't go backwards. Rolling back meant a force push or Vercel Instant Rollback, and either way the branch then disagreed with what was live until someone reconciled it. Following `main` keeps GitHub and the deployment in sync with no extra step.

**What it prevents is already prevented** — required checks, a preview per PR, and one maintainer merging deliberately. A gate earns its keep with several committers, or when shipping needs coordinating with something outside the repo. Neither is true yet.

## What stays

release-please, versioned tags, generated CHANGELOG, commitlint with a closed type list including `content`.

**A release is now a record of what shipped, not a gate in front of it.**

The reasoning is written into `FUTURE-PRS.md` next to the original design, since the idea will come back if the project ever gains committers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)