### PR TITLE
test: run the story suite in CI, behind one command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,36 @@ jobs:
 
       - name: Build all packages
         run: pnpm build
+
+  # Every story, mounted in a real browser. It catches what a type-check cannot:
+  # a component that throws on render, an import that resolves at build time and
+  # not at runtime, a token a story reaches for that no longer exists.
+  #
+  # `pnpm test` is vitest, and vitest only picks up scripts/**/*.spec.ts — so
+  # before this job nothing rendered a component anywhere in CI.
+  component-tests:
+    name: Component Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.13.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Chromium only. The runner mounts stories rather than exercising browser
+      # differences, so a second engine would triple the install for no signal.
+      - name: Install Chromium
+        run: pnpm --filter @mels-loop/ui exec playwright install --with-deps chromium
+
+      # The same command a developer runs. Building, serving and waiting live in
+      # scripts/test-e2e.sh rather than in this file, so what gates a PR and what
+      # you run locally cannot drift apart.
+      - name: Run the story suite
+        run: pnpm test:e2e

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
 		"lint": "turbo lint",
 		"lint:fix": "turbo lint:fix",
 		"test": "turbo test --log-order grouped",
-		"test-storybook": "turbo test-storybook",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"media:upload": "pnpm --filter @mels-loop/scripts s3:upload",
@@ -21,7 +20,8 @@
 		"media:download": "pnpm --filter @mels-loop/scripts s3:download",
 		"media:delete": "pnpm --filter @mels-loop/scripts s3:delete",
 		"media:list": "pnpm --filter @mels-loop/scripts s3:list",
-		"prepare": "husky"
+		"prepare": "husky",
+		"test:e2e": "turbo test:e2e"
 	},
 	"lint-staged": {
 		"*.{js,mjs,ts,tsx}": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,13 +10,13 @@
 		"lint:fix": "eslint . --fix",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
-		"test-storybook": "test-storybook",
-		"test-storybook:ci": "test-storybook --url http://127.0.0.1:6006",
 		"test": "vitest run",
 		"generate:contract": "tsx scripts/generate-contract.ts",
 		"check:contract": "tsx scripts/generate-contract.ts --check",
 		"validate-theme": "tsx scripts/validate-theme.ts",
-		"generate:styleguide": "tsx scripts/generate-styleguide-pdf.ts"
+		"generate:styleguide": "tsx scripts/generate-styleguide-pdf.ts",
+		"test:e2e": "bash scripts/test-e2e.sh",
+		"test:e2e:watch": "test-storybook"
 	},
 	"exports": {
 		"./styles/globals.css": "./dist/styles/globals.css",

--- a/packages/ui/scripts/test-e2e.sh
+++ b/packages/ui/scripts/test-e2e.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Build Storybook, serve it, run the story suite against it, clean up.
+#
+# `test-storybook` on its own needs a Storybook already running on 6006 and
+# fails with a message suggesting `yarn` if there isn't one — which is the
+# runner's own hardcoded text, not something this repo can configure. This
+# wrapper removes that trap: one command, no prerequisite, no stray server left
+# listening afterwards.
+#
+# CI runs this same script rather than repeating the sequence in YAML, so the
+# thing you run locally and the thing that gates a PR cannot drift apart.
+set -euo pipefail
+
+PORT="${PORT:-6006}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$HERE"
+
+server_pid=""
+cleanup() {
+	if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+		kill "$server_pid" 2>/dev/null || true
+		wait "$server_pid" 2>/dev/null || true
+	fi
+}
+# Fires on success, failure and Ctrl-C alike, so a failed run does not leave the
+# port occupied and make the next one fail for the wrong reason.
+trap cleanup EXIT INT TERM
+
+echo "==> Building Storybook"
+pnpm build-storybook
+
+echo "==> Serving storybook-static on :$PORT"
+pnpm exec http-server storybook-static -p "$PORT" --silent &
+server_pid=$!
+
+# Polled rather than a fixed sleep: the build is cached sometimes and cold
+# others, so any constant is either too short to be safe or too long to bear.
+for _ in $(seq 1 30); do
+	if curl -fsS -o /dev/null "http://127.0.0.1:$PORT"; then break; fi
+	sleep 1
+done
+curl -fsS -o /dev/null "http://127.0.0.1:$PORT"
+
+echo "==> Running the story suite"
+pnpm exec test-storybook --url "http://127.0.0.1:$PORT" "$@"

--- a/turbo.json
+++ b/turbo.json
@@ -23,12 +23,12 @@
 			"dependsOn": ["^build"],
 			"cache": false
 		},
-		"test-storybook": {
-			"cache": false
-		},
 		"build-storybook": {
 			"dependsOn": ["^build"],
 			"outputs": ["storybook-static/**"]
+		},
+		"test:e2e": {
+			"cache": false
 		}
 	}
 }


### PR DESCRIPTION
**Nothing in CI has ever rendered a component.** `pnpm test` is vitest, and vitest only collects `scripts/**/*.spec.ts` — so the three green checks on every PR so far covered types, formatting, a build, and ~30 tests of the S3 helper scripts. Not one of the 28 UI primitives was mounted.

## The tooling was already there

`@storybook/test-runner` is a devDependency and the scripts existed. Running them unmodified:

```
Test Suites: 32 passed, 32 total
Tests:       47 passed, 47 total
```

It had simply never been invoked, by CI or by anyone.

## One command, not a sequence

`test-storybook` on its own is a trap — it needs a Storybook already listening on 6006, and when there isn't one it fails with advice to run **`yarn`**, which is the runner's own hardcoded text and nothing this repo can configure.

So the build, the static server, the readiness poll and the cleanup live in `packages/ui/scripts/test-e2e.sh`, and **CI and a developer run the same command**:

```bash
pnpm test:e2e
```

Nothing about the sequence is duplicated in YAML, so what gates a PR and what you run locally can't drift. Verified: 32/32, and no server left listening afterwards — cleanup runs on success, failure and Ctrl-C alike.

## Script names

Renamed while they were still new:

| before | after | |
|---|---|---|
| `test-storybook` | `test:e2e` | self-contained — builds, serves, tests, cleans up |
| `test-storybook:ci` | *(gone)* | CI uses the same command as everyone else |
| — | `test:e2e:watch` | assumes a running Storybook; the fast local loop |

Turbo task key follows.

## What it catches, honestly

Narrow but real and covered nowhere else: a component that throws on render, an import that resolves at build time but not at runtime, a token a story reaches for that no longer exists.

**It is a smoke test, not an interaction suite.** No story has a `play()` function — I checked twice, having first been fooled by `grep play:` matching `display:`. Adding real interaction tests is the obvious next step now that something runs them.

Chromium only: the runner mounts stories rather than exercising engine differences, so a second browser triples the install for no signal.

## Not in this PR

- **`play()` interaction tests** — the actual behavioural coverage
- **`@storybook/addon-a11y` + `axe-playwright`** — WCAG checks on every story via a `postVisit` hook. High value for a bilingual site, but two new dependencies and its own PR
- **The 67-file Playwright suite on `rewrite`** — `FUTURE-PRS.md` proposed restoring it. It never ran once, has no committed baselines, and its config sets `updateSnapshots: 'none'` so every `toHaveScreenshot()` fails on a missing baseline. Growing `play()` coverage on a runner that works beats resurrecting one that never did

🤖 Generated with [Claude Code](https://claude.com/claude-code)