### PR TITLE
fix: validate the contact form's own configuration

### DIFF
--- a/apps/web/src/app/api/contact/route.ts
+++ b/apps/web/src/app/api/contact/route.ts
@@ -122,6 +122,27 @@ export async function POST(request: NextRequest) {
 		const toEmail = process.env.CONTACT_TO_EMAIL || 'about@melsloop.com';
 		const fromEmail = process.env.CONTACT_FROM_EMAIL || 'noreply@melsloop.com';
 
+		/*
+		 * The same check the visitor's address gets, applied to our own
+		 * configuration — which until now was trusted blindly.
+		 *
+		 * A Postmark server token was once pasted into CONTACT_FROM_EMAIL. The
+		 * request went out with `From: Mel's Loop <a-guid-here>`, Postmark
+		 * rejected it and echoed the offending value back, and the error path
+		 * below wrote that response to the logs. A secret in any of these
+		 * variables leaves the same way. Failing here means there is nothing to
+		 * echo.
+		 */
+		if (!EMAIL_PATTERN.test(fromEmail) || !EMAIL_PATTERN.test(toEmail)) {
+			console.error(
+				'Contact form misconfigured: CONTACT_FROM_EMAIL or CONTACT_TO_EMAIL is not an email address',
+			);
+			return NextResponse.json(
+				{ error: 'Email service not configured' },
+				{ status: 500 },
+			);
+		}
+
 		if (!token) {
 			/*
 			 * Local development without credentials logs instead of sending, so
@@ -173,7 +194,18 @@ export async function POST(request: NextRequest) {
 			return NextResponse.json({ success: true });
 		}
 
-		console.error('Postmark error:', response.status, data);
+		/*
+		 * The code and message, not the response object. Postmark echoes the
+		 * offending input back in its errors — an invalid From address is
+		 * quoted verbatim — so logging the whole thing means logging whatever
+		 * was misconfigured, secrets included.
+		 */
+		console.error(
+			'Postmark error:',
+			response.status,
+			data?.ErrorCode,
+			data?.Message,
+		);
 		return NextResponse.json({ error: 'Failed to send' }, { status: 500 });
 	} catch (error) {
 		console.error('Contact form error:', error);


### PR DESCRIPTION
Two changes, both about what happens when **the endpoint** is misconfigured rather than when a visitor is.

## What happened

The route applied `EMAIL_PATTERN` to the address a visitor typed and trusted its own configuration blindly.

A Postmark **server token** was pasted into `CONTACT_FROM_EMAIL`. The request went out as `From: Mel's Loop <a-guid>`, Postmark rejected it with `ErrorCode 300` and **quoted the offending value back**, and the error path logged the whole response object — putting the token into the platform logs and into a terminal.

The token has been rotated.

## The two changes

**Validate our own config**, with the check that already exists in the file:

```ts
if (!EMAIL_PATTERN.test(fromEmail) || !EMAIL_PATTERN.test(toEmail)) { … }
```

**Log the code, not the response:**

```diff
-console.error('Postmark error:', response.status, data);
+console.error('Postmark error:', response.status, data?.ErrorCode, data?.Message);
```

Together: a secret in any of those variables fails *before* the request is made, and the failure has nothing to echo.

## Verified against the original fault

Ran the built app with `CONTACT_FROM_EMAIL` set to the same GUID shape:

```
POST /api/contact  →  500 {"error":"Email service not configured"}
log: Contact form misconfigured: CONTACT_FROM_EMAIL or CONTACT_TO_EMAIL is not an email address
```

Postmark is never contacted, and the log names the variable without printing its contents.

## Not addressed, deliberately

- the `|| 'about@melsloop.com'` fallbacks
- `ErrorCode 406` returning 500, so a suppressed recipient tells the visitor to "try again" indefinitely

Both real, both cosmetic beside a leaked credential.

## Context

None of tonight's outage was a code bug — the route behaved correctly throughout. The causes were a non-existent mailbox, cascading Postmark suppressions, swapped env vars, Cloudflare overwriting the SPF record, and a stale Google MX inside its one-hour TTL. This PR only makes the next misconfiguration say what it is instead of leaking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)